### PR TITLE
Update vorob_optim_parallel

### DIFF
--- a/R/vorob_optim_parallel.R
+++ b/R/vorob_optim_parallel.R
@@ -52,8 +52,8 @@ vorob_optim_parallel <- function(x, integration.points,integration.weights=NULL,
 		arg1 <- as.numeric((intpoints.oldmean-T) / intpoints.oldsd)
     arg2 <- as.numeric((qnorm(alpha) - a)/sqrt(c-1))
     arg3 <- as.numeric(-sqrt(1-1/c))
-    arg1[arg1==Inf] <- 1000 ; arg1[arg1==-Inf] <- -1000 ; arg2[arg2==Inf] <- 1000
-    arg2[arg2==-Inf] <- -1000 ; arg3[arg3==Inf] <- 1000 ; arg3[arg3==-Inf] <- -1000
+    arg1[arg1==Inf] <- 1000 ; arg1[arg1==-Inf] <- -1000 
+    arg2[arg2==Inf] <- 1000 ; arg2[arg2==-Inf] <- -1000
     if(typeEx==">"){
       # pbivnorm - c.d.f of the bivariate gaussian distribution
       term1 <- pbivnorm(arg1,arg2,arg3)  # Type II error

--- a/R/vorob_optim_parallel.R
+++ b/R/vorob_optim_parallel.R
@@ -52,7 +52,8 @@ vorob_optim_parallel <- function(x, integration.points,integration.weights=NULL,
 		arg1 <- as.numeric((intpoints.oldmean-T) / intpoints.oldsd)
     arg2 <- as.numeric((qnorm(alpha) - a)/sqrt(c-1))
     arg3 <- as.numeric(-sqrt(1-1/c))
-
+    arg1[arg1==Inf] <- 1000 ; arg1[arg1==-Inf] <- -1000 ; arg2[arg2==Inf] <- 1000
+    arg2[arg2==-Inf] <- -1000 ; arg3[arg3==Inf] <- 1000 ; arg3[arg3==-Inf] <- -1000
     if(typeEx==">"){
       # pbivnorm - c.d.f of the bivariate gaussian distribution
       term1 <- pbivnorm(arg1,arg2,arg3)  # Type II error
@@ -61,6 +62,7 @@ vorob_optim_parallel <- function(x, integration.points,integration.weights=NULL,
     }else{
       # Readjust arg2 for excursion below T
       arg2 <- as.numeric((qnorm(alpha) + a)/sqrt(c-1))
+      arg2[arg2==Inf] <- 1000 ; arg2[arg2==-Inf] <- -1000
       # pbivnorm - c.d.f of the bivariate gaussian distribution
       term1 <- pbivnorm(-arg1,arg2,arg3) # Type II error
       term2 <- pbivnorm(-arg1,-arg2,-arg3) * penalisation # Type I error


### PR DESCRIPTION
There was a problem with the pbivnorm function which doesn't handle +-Inf well in inputs, so I replaced the infinite values of the arg1, arg2 and arg3 terms by +-1000. With this modification, there is no more NaN at the output (this did not happen often in small dimension but in large dimension it became quite annoying).
Below are the two front images ( https://imgur.com/vs9hz2L ) and after ( https://imgur.com/SEvJU7X ) the correction for the Branin function in dimension 2 with NaN in white. 